### PR TITLE
Serial debugger

### DIFF
--- a/andy_elf/Makefile
+++ b/andy_elf/Makefile
@@ -67,6 +67,7 @@ test.elf: kickoff.o exceptions.o basic_console.o cfuncs.o stdio_funcs.o \
 	ld -b elf32-i386 kickoff.o exceptions.o basic_console.o cfuncs.o stdio_funcs.o \
 		c_exceptions.o mmgr.o panic.o inkernel_memory_tests.o memops.o ioports.o cpuid.o \
 		-L 8259pic/ -l8259pic -Lacpi/ -lacpi -Ldrivers/ata_pio/ -lata_pio -Lscheduler/ -l scheduler \
+		-Ldrivers/early_serial/ -learly_serial \
 		-Ttext 0x7E00 -Tdata 0xE000 -Trodata 0x9000 \
 		-static -nostartfiles -nodefaultlibs -nostdlib -nolibc -m elf_i386 --oformat elf32-i386 -o test.elf
 

--- a/andy_elf/basic_console.inc
+++ b/andy_elf/basic_console.inc
@@ -3,3 +3,6 @@ extern PMPrintString
 extern PMPrintStringLen
 extern PMPrintChar
 extern PMScrollConsole
+
+; remove this definition to disable serial console
+%define SERIAL_CONSOLE 1

--- a/andy_elf/basic_console.inc
+++ b/andy_elf/basic_console.inc
@@ -3,6 +3,3 @@ extern PMPrintString
 extern PMPrintStringLen
 extern PMPrintChar
 extern PMScrollConsole
-
-; remove this definition to disable serial console
-%define SERIAL_CONSOLE 1

--- a/andy_elf/basic_console.s
+++ b/andy_elf/basic_console.s
@@ -7,6 +7,8 @@ global PMPrintString
 global PMPrintChar
 global PMPrintStringLen
 
+global early_serial_putchar
+
 %include "memlayout.inc"
 
 ;Print an ASCIIZ string in protected mode.
@@ -39,6 +41,13 @@ PMPrintString:
 	lodsb
 	test al, al
 	jz pm_string_done	;if the next char is 0, then exit
+
+	%ifdef SERIAL_CONSOLE
+	push al
+	call early_serial_putchar
+	pop al
+	%endif
+
 	cmp al, 0x0d		;CR
 	jz pm_carraige_rtn
 	cmp al, 0x0a		;LF
@@ -110,6 +119,13 @@ PMPrintStringLen:
 	dec ecx
 	test ecx,ecx
 	jz pm_string_done_len	;if we get to zero, then exit
+
+	%ifdef SERIAL_CONSOLE
+	push al
+	call early_serial_putchar
+	pop al
+	%endif
+
 	cmp al, 0x0d		;CR
 	jz pm_carraige_rtn_len
 	cmp al, 0x0a		;LF
@@ -155,6 +171,12 @@ PMPrintChar:
 	mov ax, DisplayMemorySeg
 	mov es, ax
 	mov edi, TextConsoleOffset
+
+	%ifdef SERIAL_CONSOLE
+	push bl
+	call early_serial_putchar
+	pop bl
+	%endif
 
 	xor eax,eax
 	mov al, byte [CursorRowPtr]

--- a/andy_elf/basic_console.s
+++ b/andy_elf/basic_console.s
@@ -7,7 +7,10 @@ global PMPrintString
 global PMPrintChar
 global PMPrintStringLen
 
-global early_serial_putchar
+extern early_serial_putchar
+
+; remove this definition to disable serial console
+%define SERIAL_CONSOLE 1
 
 %include "memlayout.inc"
 
@@ -43,9 +46,9 @@ PMPrintString:
 	jz pm_string_done	;if the next char is 0, then exit
 
 	%ifdef SERIAL_CONSOLE
-	push al
+	push ax
 	call early_serial_putchar
-	pop al
+	pop ax
 	%endif
 
 	cmp al, 0x0d		;CR
@@ -121,9 +124,9 @@ PMPrintStringLen:
 	jz pm_string_done_len	;if we get to zero, then exit
 
 	%ifdef SERIAL_CONSOLE
-	push al
+	push ax
 	call early_serial_putchar
-	pop al
+	pop ax
 	%endif
 
 	cmp al, 0x0d		;CR
@@ -173,9 +176,9 @@ PMPrintChar:
 	mov edi, TextConsoleOffset
 
 	%ifdef SERIAL_CONSOLE
-	push bl
+	push bx
 	call early_serial_putchar
-	pop bl
+	pop bx
 	%endif
 
 	xor eax,eax

--- a/andy_elf/drivers/Makefile
+++ b/andy_elf/drivers/Makefile
@@ -1,9 +1,13 @@
 .PHONY: ata_pio
 
-all: ata_pio
+all: ata_pio early_serial
 
 ata_pio:
 	make -C ata_pio
 
+early_serial:
+	make -C early_serial
+
 clean:
 	make -C ata_pio clean
+	make -C early_serial clean

--- a/andy_elf/drivers/Makefile
+++ b/andy_elf/drivers/Makefile
@@ -1,4 +1,4 @@
-.PHONY: ata_pio
+.PHONY: ata_pio early_serial
 
 all: ata_pio early_serial
 

--- a/andy_elf/drivers/early_serial/Makefile
+++ b/andy_elf/drivers/early_serial/Makefile
@@ -1,0 +1,7 @@
+all: libearly_serial.a
+
+serial_lowlevel.o: serial_lowlevel.asm
+	nasm -f elf32 serial_lowlevel.asm
+
+libearly_serial.a: serial_lowlevel.o
+	ar rcs libearly_serial.a serial_lowlevel.o

--- a/andy_elf/drivers/early_serial/Makefile
+++ b/andy_elf/drivers/early_serial/Makefile
@@ -5,3 +5,6 @@ serial_lowlevel.o: serial_lowlevel.asm
 
 libearly_serial.a: serial_lowlevel.o
 	ar rcs libearly_serial.a serial_lowlevel.o
+
+clean:
+	rm -f *.a *.o

--- a/andy_elf/drivers/early_serial/serial.h
+++ b/andy_elf/drivers/early_serial/serial.h
@@ -1,0 +1,5 @@
+/*
+in serial_lowlevel.asm
+*/
+void early_serial_lowlevel_init();
+void early_serial_putchar(char ch);

--- a/andy_elf/drivers/early_serial/serial_lowlevel.asm
+++ b/andy_elf/drivers/early_serial/serial_lowlevel.asm
@@ -1,0 +1,82 @@
+[bits 32]
+
+;All I/O ports are 8 bits wide
+%define SERIAL_BASE         0x3F8
+;these ports are changed if DLAB (Divisor Latch Access Bit) is 1
+%define SERIAL_DATA         SERIAL_BASE + 0
+%define SERIAL_INT_ENABLE   SERIAL_BASE + 1
+;if DLAB is 1 then the first two ports are reassigned as follows
+%define SERIAL_DIVISOR_LSB  SERIAL_BASE + 0 
+%define SERIAL_DIVISOR_MSB  SERIAL_BASE + 1
+
+%define SERIAL_INTERRUPT_ID     SERIAL_BASE + 2
+%define SERIAL_LINE_CONTROL     SERIAL_BASE + 3
+%define SERIAL_MODEL_CONTROL    SERIAL_BASE + 4
+%define SERIAL_LINE_STATUS      SERIAL_BASE + 5
+%define SERIAL_MODEM_STATUS     SERIAL_BASE + 6
+%define SERIAL_SCRATCH          SERIAL_BASE + 7
+
+global early_serial_lowlevel_init
+global early_serial_putchar
+
+; Purpose - initialises the first serial port (COM1, ttyS0 or however you want to name it)
+; This is "early", i.e. loadable before memory management etc, and is only intended for debugging 
+; output on the serial port.
+; Hard-sets 9600 8-N-1 parameters
+early_serial_lowlevel_init:
+    push ebp
+    mov ebp, esp
+
+    ;Configure the baud rate.
+    ;First we need to access the divsor
+    xor ax, ax
+    in al, SERIAL_LINE_CONTROL
+    or al, 0x80    ;set the MSB
+    out SERIAL_LINE_CONTROL, al
+    ;Now, we can use SERIAL_DIVISOR_xSB
+    ;we want 9600 baud, which is a divisor of 12 or 0x0C
+    xor ax, ax
+    out SERIAL_DIVISOR_MSB, al
+    mov al, 0x0C
+    out SERIAL_DIVISOR_LSB, al
+
+    ;Now clear the DLAB bit. This is done by clearing the MSB of the line control register.
+    xor ax, ax
+    in al, SERIAL_LINE_CONTROL
+    and al, 0x7F
+    ;Data bits are bits 0 and 1 of the line control register. 11 => 8 bits.
+    or al, 0x03
+    ;Stop bits is bit 2 of the line control register. 0 => 1 stop bit
+    and al, 0xFB
+    ;Parity is bits 3,4,5 of the line control register. xx0 => No parity
+    and al, 0xC7
+    out SERIAL_LINE_CONTROL, al
+
+    ;We don't yet have PM interrupts set up. So we can't use them.
+    xor al, al
+    out SERIAL_INT_ENABLE, al
+
+    pop ebp
+    ret
+
+; Purpose - writes a character to the (initialised) serial port
+; This is a low-performance, "early" implementation designed to be able to operate before interrupts are available
+; For this reason, it will always wait until the line is available and the char written before returning.
+; Arguments: one 8-bit ASCII character to write
+early_serial_putchar:
+    push ebp
+    mov ebp, esp
+
+    ;Check if the transmit buffer is empty yet
+    _early_serial_putchar_wait_loop:
+    in al, SERIAL_LINE_STATUS
+    test al, 0x20    ;we need to check bit 5
+    jz _early_serial_putchar_wait_loop ;zero flag set => result of AND was zero => serial line is transmitting
+
+    ;now write the char
+    mov al, BYTE PTR [ebp+8]
+    out SERIAL_DATA, al
+
+    ;return
+    pop ebp
+    ret

--- a/andy_elf/kickoff.s
+++ b/andy_elf/kickoff.s
@@ -2,6 +2,9 @@
 section .text
 global _start
 
+; remove this definition to disable serial console (also remove in basic_console.s)
+%define SERIAL_CONSOLE 1
+
 extern early_serial_lowlevel_init
 
 %include "basic_console.inc"

--- a/andy_elf/kickoff.s
+++ b/andy_elf/kickoff.s
@@ -2,6 +2,8 @@
 section .text
 global _start
 
+extern early_serial_lowlevel_init
+
 %include "basic_console.inc"
 %include "memlayout.inc"
 %include "exceptions.inc"
@@ -83,6 +85,9 @@ mov ds, ax
 mov es, ax
 mov ss, ax
 mov esp, 0x7fff0	;set stack pointer to the end of conventional RAM
+
+;set up serial debugging output. Vital if SERIAL_CONSOLE is defined in basic_console.inc
+call early_serial_lowlevel_init
 
 mov byte [CursorColPtr], dl
 mov byte [CursorRowPtr], dh

--- a/elf_loader/.gitignore
+++ b/elf_loader/.gitignore
@@ -1,3 +1,3 @@
 elf_boot
 *.dump
-
+*.log

--- a/elf_loader/bochsrc.txt
+++ b/elf_loader/bochsrc.txt
@@ -30,18 +30,18 @@ private_colormap: enabled=0
 clock: sync=none, time0=local, rtc_sync=0
 # no cmosimage
 # no loader
-log: -
+log: bochs.log
 logprefix: %t%e%d
 panic: action=ask
 error: action=report
 info: action=report
 debug: action=ignore, harddrv=report
 keyboard: type=mf, serial_delay=250, paste_delay=100000, keymap=
-user_shortcut: keys=none
+#user_shortcut: keys=none
 mouse: enabled=0, type=ps2, toggle=ctrl+mbutton
 parport1: enabled=1, file=""
 parport2: enabled=0
-com1: enabled=1, mode=null, dev=""
+com1: enabled=1, mode=file, dev=serial.log
 com2: enabled=0
 com3: enabled=0
 com4: enabled=0


### PR DESCRIPTION
Adding in a simple serial driver with minimal dependencies and using it for logging out startup messages.

This is then used by Bochs to output to a file `serial.log` for improved debugging