### PR TITLE
More mmgr improvements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "files.associations": {
+        "process.h": "c",
+        "fat_fileops.h": "c",
+        "spinlock.h": "c",
+        "functional": "c"
+    }
+}

--- a/andy_elf/c_exceptions.c
+++ b/andy_elf/c_exceptions.c
@@ -1,18 +1,7 @@
 #include <types.h>
 #include <stdio.h>
-
-/*
-Pagefault error code bitfield
-*/
-#define PAGEFAULT_ERR_PRESENT 1<< 0 // 	When set, the page fault was caused by a page-protection violation. When not set, it was caused by a non-present page.
-#define PAGEFAULT_ERR_WRITE   1<< 1 //When set, the page fault was caused by a write access. When not set, it was caused by a read access.
-#define PAGEFAULT_ERR_USER    1<< 2 // When set, the page fault was caused while CPL = 3. This does not necessarily mean that the page fault was a privilege violation.
-#define PAGEFAULT_ERR_RESERVEDWRITE 1<< 3 // 	When set, one or more page directory entries contain reserved bits which are set to 1. This only applies when the PSE or PAE flags in CR4 are set to 1.
-#define PAGEFAULT_ERR_INSFETCH 1<< 4 //When set, the page fault was caused by an instruction fetch. This only applies when the No-Execute bit is supported and enabled.
-#define PAGEFAULT_ERR_PKEY 1<< 5    // 	When set, the page fault was caused by a protection-key violation. The PKRU register (for user-mode accesses) or PKRS MSR (for supervisor-mode accesses) specifies the protection key rights.
-#define PAGEFAULT_ERR_SS 1<< 6      // When set, the page fault was caused by a shadow stack access.
-#define PAGEFAULT_ERR_SGX 1<< 15    //When set, the fault was due to an SGX violaton. The fault is unrelated to ordinary paging.
-#define PAGEFAULT_ERR_PRESENT 1<< 0
+#include <sys/mmgr.h>
+#include <sys/pagefault.h>
 
 /**
 higher-level exception handlers
@@ -39,8 +28,11 @@ void c_except_invalidop(uint32_t faulting_addr, uint32_t faulting_codeseg, uint3
   kprintf("ERROR: Invalid opcode, occurring at 0x%x:0x%x\r\n", faulting_codeseg, faulting_addr);
 }
 
-void c_except_pagefault(uint32_t pf_load_addr, uint32_t error_code, uint32_t faulting_addr, uint32_t faulting_codeseg, uint32_t eflags)
+uint32_t c_except_pagefault(uint32_t pf_load_addr, uint32_t error_code, uint32_t faulting_addr, uint32_t faulting_codeseg, uint32_t eflags)
 {
+  uint8_t rc = handle_allocation_fault(pf_load_addr, error_code, faulting_addr, faulting_codeseg, eflags);
+  if(rc==0) return 0; //page fault was handled!
+  
   kprintf("ERROR: Page fault, occurring at 0x%x:0x%x\r\n", faulting_codeseg, faulting_addr);
   kprintf("Page fault loading address was 0x%x\r\n", pf_load_addr);
   if(error_code&PAGEFAULT_ERR_PRESENT) { kputs("Page-protection violation."); } else { kputs("Page was not present,."); }
@@ -48,5 +40,5 @@ void c_except_pagefault(uint32_t pf_load_addr, uint32_t error_code, uint32_t fau
   if(error_code&PAGEFAULT_ERR_INSFETCH) { kputs("Page fault caused by instruction fetch."); }
   if(error_code&PAGEFAULT_ERR_WRITE) { kputs("Page fault caused by write access"); } else { kputs("Page fault caused by read access"); }
 
-
+  return 1;
 }

--- a/andy_elf/exceptions.s
+++ b/andy_elf/exceptions.s
@@ -174,9 +174,15 @@ IPageFault:	;leaves error code
 	mov eax, cr2
 	push eax
 	call c_except_pagefault
+	cmp eax, 0
+	jz .recovered
+
 	mov eax, PageFaultMsg
 	call FatalMsg
-
+	.recovered:
+	add esp, 8
+	iret
+	
 IFloatingPointExcept:
 	mov eax, FPExceptMsg
 	call FatalMsg

--- a/andy_elf/include/memops.h
+++ b/andy_elf/include/memops.h
@@ -1,6 +1,7 @@
 #include <types.h>
 
 void *memset(void *s, uint8_t c, size_t n);
+void *memset_dw(void *s, uint32_t c, size_t n_dwords);
 void *memcpy(void *dest, const void *src, size_t n);
 void *memcpy_dw(void *dest, const void *src, size_t n_dwords);
 

--- a/andy_elf/include/process.h
+++ b/andy_elf/include/process.h
@@ -73,6 +73,7 @@ struct ProcessTableEntry {
   struct SavedRegisterStates32 saved_regs;  //offset 0x28
   //open files
   struct FilePointer files[FILE_MAX];
+  pid_t pid;
 } __attribute__((packed));
 
 

--- a/andy_elf/include/spinlock.h
+++ b/andy_elf/include/spinlock.h
@@ -1,0 +1,4 @@
+#include <types.h>
+
+//use an int64 for the spinlock. needs to occupy a whole cache line; but the lock itself is the LSB only.
+typedef uint64_t *spinlock_t;

--- a/andy_elf/include/spinlock.h
+++ b/andy_elf/include/spinlock.h
@@ -1,4 +1,15 @@
 #include <types.h>
 
 //use an int64 for the spinlock. needs to occupy a whole cache line; but the lock itself is the LSB only.
-typedef uint64_t *spinlock_t;
+typedef uint64_t __attribute__ ((aligned (64))) *spinlock_t;
+
+
+/** 
+ * Atomically acquire the given lock if it's free, or loop until it is available
+*/
+void acquire_spinlock(spinlock_t *lock);
+
+/**
+ * Release a previouisly acquired lock
+*/
+void release_spinlock(spinlock_t *lock);

--- a/andy_elf/include/sys/mmgr.h
+++ b/andy_elf/include/sys/mmgr.h
@@ -61,6 +61,10 @@ struct PhysMapEntry {
 #define PAGE_SIZE         0x1000  //4k pages
 #define PAGE_SIZE_DWORDS  0x200
 
+
+//We only create mapped app pagedirs in this region.
+#define APP_PAGEDIRS_BASE (vaddr)0xC0000000
+
 /* external facing functions */
 /**
 initialise the memory manager, applying protections as per the BiosMemoryMap pointed to
@@ -104,6 +108,16 @@ Returns:
 virtual memory to complete or `pages` was 0.
 */
 void * vm_map_next_unallocated_pages(uint32_t *root_page_dir, uint32_t flags, void **phys_addr, size_t pages);
+
+/**
+ * Maps the contents of the given paging dir into memory, on a 4mb boundary
+*/
+uint32_t *map_app_pagingdir(vaddr paging_dir_phys, vaddr starting_from);
+
+/**
+ * Unmaps and invalidates the given paging dir, the argument must have previously been obtained from map_app_pagingdir
+*/
+void unmap_app_pagingdir(uint32_t *mapped_pd);
 
 /* internal functions */
 void setup_paging();

--- a/andy_elf/include/sys/mmgr.h
+++ b/andy_elf/include/sys/mmgr.h
@@ -115,7 +115,7 @@ Arguments:
 */
 uint8_t _resolve_vptr(void *vmem_ptr, uint16_t *dir, uint16_t *off);
 
-uint32_t *initialise_app_pagingdir(void *root_dir_phys, void *page_one_phys);
+uint32_t *initialise_app_pagingdir(void **phys_ptr_list, size_t phys_ptr_count);
 
 /** called from the page-fault handler for JIT allocation*/
 uint8_t handle_allocation_fault(uint32_t pf_load_addr, uint32_t error_code, uint32_t faulting_addr, uint32_t faulting_codeseg, uint32_t eflags);

--- a/andy_elf/include/sys/mmgr.h
+++ b/andy_elf/include/sys/mmgr.h
@@ -58,7 +58,8 @@ struct PhysMapEntry {
 #define MP_OSBITS_MASK 0xF00  //bitmask for the 3 os-dependent bits
 #define MP_ADDRESS_MASK 0xFFFFF000
 
-#define PAGE_SIZE     0x1000  //4k pages
+#define PAGE_SIZE         0x1000  //4k pages
+#define PAGE_SIZE_DWORDS  0x200
 
 /* external facing functions */
 /**

--- a/andy_elf/include/sys/mmgr.h
+++ b/andy_elf/include/sys/mmgr.h
@@ -52,14 +52,14 @@ struct PhysMapEntry {
 #define MP_PAGESIZE   1 << 7  //if this is 0 then the address refers to a page table, otherwise to a 4Mib block
 #define MP_GLOBAL     1 << 8  //don't invalidate when CR3 changes if set
 
-#define MPC_SPARSE    1 << 9  //custom attribute - if this is 1 then the page is "sparse", i.e. not present but can be mapped in
+#define MPC_PAGINGDIR    1 << 9  //custom attribute - if this is 1 then the page is a paging directory, i.e. not present but can be mapped in
 #define MP_PAGEATTRIBUTE 1 << 12 //if Page Attribute Table is supported, forms a 3-bit index value with MP_PWT and MP_PCD
 
 #define MP_OSBITS_MASK 0xF00  //bitmask for the 3 os-dependent bits
 #define MP_ADDRESS_MASK 0xFFFFF000
 
 #define PAGE_SIZE         0x1000  //4k pages
-#define PAGE_SIZE_DWORDS  0x200
+#define PAGE_SIZE_DWORDS  0x400
 
 
 //We only create mapped app pagedirs in this region.

--- a/andy_elf/include/sys/mmgr.h
+++ b/andy_elf/include/sys/mmgr.h
@@ -117,4 +117,6 @@ uint8_t _resolve_vptr(void *vmem_ptr, uint16_t *dir, uint16_t *off);
 
 uint32_t *initialise_app_pagingdir(void *root_dir_phys, void *page_one_phys);
 
+/** called from the page-fault handler for JIT allocation*/
+uint8_t handle_allocation_fault(uint32_t pf_load_addr, uint32_t error_code, uint32_t faulting_addr, uint32_t faulting_codeseg, uint32_t eflags);
 #endif

--- a/andy_elf/include/sys/mmgr.h
+++ b/andy_elf/include/sys/mmgr.h
@@ -51,7 +51,9 @@ struct PhysMapEntry {
 #define MP_DIRTY      1 << 6  //if this is 0 then the page has not been written, if 1 then it has
 #define MP_PAGESIZE   1 << 7  //if this is 0 then the address refers to a page table, otherwise to a 4Mib block
 #define MP_GLOBAL     1 << 8  //don't invalidate when CR3 changes if set
-#define MP_PAGEATTRIBUTE 1 << 12 //1 if Page Attribute Table is supported. Keep to 0
+
+#define MPC_SPARSE    1 << 9  //custom attribute - if this is 1 then the page is "sparse", i.e. not present but can be mapped in
+#define MP_PAGEATTRIBUTE 1 << 12 //if Page Attribute Table is supported, forms a 3-bit index value with MP_PWT and MP_PCD
 
 #define MP_OSBITS_MASK 0xF00  //bitmask for the 3 os-dependent bits
 #define MP_ADDRESS_MASK 0xFFFFF000

--- a/andy_elf/include/sys/pagefault.h
+++ b/andy_elf/include/sys/pagefault.h
@@ -1,0 +1,12 @@
+/*
+Pagefault error code bitfield
+*/
+#define PAGEFAULT_ERR_PRESENT 1<< 0 // 	When set, the page fault was caused by a page-protection violation. When not set, it was caused by a non-present page.
+#define PAGEFAULT_ERR_WRITE   1<< 1 //When set, the page fault was caused by a write access. When not set, it was caused by a read access.
+#define PAGEFAULT_ERR_USER    1<< 2 // When set, the page fault was caused while CPL = 3. This does not necessarily mean that the page fault was a privilege violation.
+#define PAGEFAULT_ERR_RESERVEDWRITE 1<< 3 // 	When set, one or more page directory entries contain reserved bits which are set to 1. This only applies when the PSE or PAE flags in CR4 are set to 1.
+#define PAGEFAULT_ERR_INSFETCH 1<< 4 //When set, the page fault was caused by an instruction fetch. This only applies when the No-Execute bit is supported and enabled.
+#define PAGEFAULT_ERR_PKEY 1<< 5    // 	When set, the page fault was caused by a protection-key violation. The PKRU register (for user-mode accesses) or PKRS MSR (for supervisor-mode accesses) specifies the protection key rights.
+#define PAGEFAULT_ERR_SS 1<< 6      // When set, the page fault was caused by a shadow stack access.
+#define PAGEFAULT_ERR_SGX 1<< 15    //When set, the fault was due to an SGX violaton. The fault is unrelated to ordinary paging.
+#define PAGEFAULT_ERR_PRESENT 1<< 0

--- a/andy_elf/memops.asm
+++ b/andy_elf/memops.asm
@@ -2,6 +2,7 @@
 
 section .text
 global memset
+global memset_dw
 global memcpy
 global memcpy_dw
 global mb       ;memory barrier
@@ -45,6 +46,36 @@ memset:
   pop ebp
   ret
 
+;sets the given memory buffer to the provided DWORD value
+;Arguments:
+;1. pointer to the buffer to set (in current DS)
+;2. dword value to set (uint32_t)
+;3. size of the buffer in dwords (uint32_t). NOTE that this is 1/4 of the byte length!
+;Returns:
+;- pointer to the buffer that was set
+memset_dw:
+  push ebp
+  mov ebp, esp
+  push edi
+  push es
+  push ecx
+
+  mov ax, ds
+  mov es, ax
+  mov edi, [ebp+8]    ;first arg - buffer
+
+  mov eax, dword [ebp+12] ;second arg - value to set
+  mov ecx, dword [ebp+16] ;third arg  - dword count to copy
+
+  rep stosd
+
+  pop ecx
+  pop es
+  mov eax, edi
+  pop edi
+  pop ebp
+  ret
+  
 ;copy data from one memory buffer to another
 ;Arguments:
 ;1. pointer to the destination buffer

--- a/andy_elf/mmgr/process.c
+++ b/andy_elf/mmgr/process.c
@@ -97,7 +97,6 @@ struct ProcessTableEntry* new_process()
   cli();
   struct ProcessTableEntry *e = get_next_available_process();
   if(e==NULL) {
-    sti();
     return NULL;  //failed so bail out.
   }
 
@@ -111,7 +110,6 @@ struct ProcessTableEntry* new_process()
   if(c<3) {
     kprintf("ERROR Cannot allocate memory for new process\r\n");
     remove_process(e);
-    sti();
     return NULL;
   }
   e->root_paging_directory_phys = phys_ptrs[0];

--- a/andy_elf/mmgr/process.c
+++ b/andy_elf/mmgr/process.c
@@ -115,19 +115,20 @@ struct ProcessTableEntry* new_process()
   e->root_paging_directory_phys = phys_ptrs[0];
   kprintf("DEBUG process paging directory at physical address 0x%x\r\n", e->root_paging_directory_phys);
 
-  e->root_paging_directory_kmem = initialise_app_pagingdir(e->root_paging_directory_phys, phys_ptrs[1]);
+  e->root_paging_directory_kmem = initialise_app_pagingdir(phys_ptrs, 6);
 
-  //now set up stack at the end of the process's VRAM
-  kputs("DEBUG new_process setting up process stack\r\n");
-  void *process_stack = k_map_page(e->root_paging_directory_kmem, phys_ptrs[2], 1023, 1023, MP_USER|MP_READWRITE);
-  kprintf("DEBUG new_process Set up 4k stack at 0x%x in process space\r\n", process_stack);
-  e->stack_page_count = 1;
-  e->saved_regs.esp = 0xFFFFFFF8;
-  e->stack_phys_ptr = phys_ptrs[2];
-  e->stack_kmem_ptr = (uint32_t *)k_map_next_unallocated_pages(MP_READWRITE, &phys_ptrs[2], 1);
-  if(e->stack_kmem_ptr==NULL) {
-    kputs("ERROR new_process could not map process stack into kmem for setup\r\n");
-  }
+  //stack etc. are now set up in initialise_app_pagingdir
+  // //now set up stack at the end of the process's VRAM
+  // kputs("DEBUG new_process setting up process stack\r\n");
+  // void *process_stack = k_map_page(e->root_paging_directory_kmem, phys_ptrs[2], 1023, 1023, MP_USER|MP_READWRITE);
+  // kprintf("DEBUG new_process Set up 4k stack at 0x%x in process space\r\n", process_stack);
+  // e->stack_page_count = 1;
+  // e->saved_regs.esp = 0xFFFFFFF8;
+  // e->stack_phys_ptr = phys_ptrs[2];
+  // e->stack_kmem_ptr = (uint32_t *)k_map_next_unallocated_pages(MP_READWRITE, &phys_ptrs[2], 1);
+  // if(e->stack_kmem_ptr==NULL) {
+  //   kputs("ERROR new_process could not map process stack into kmem for setup\r\n");
+  // }
 
   //finally setup stin, stdout, stderr
   e->files[0].type = FP_TYPE_CONSOLE;

--- a/andy_elf/process/elfloader.c
+++ b/andy_elf/process/elfloader.c
@@ -59,7 +59,7 @@ void _elf_next_segment_loaded(VFatOpenFile *fp, uint8_t status, size_t bytes_rea
 
 void elf_load_next_segment(VFatOpenFile *fp, struct elf_parsed_data *t)
 {
-
+  cli();
   if(t->_scanned_segment_count>=t->program_headers_count) {
     kprintf("DEBUG elf_load_next_segment Loaded all %l section headers.\r\n", t->program_headers_count);
     t->callback(E_OK, t, t->extradata);
@@ -115,14 +115,10 @@ void elf_load_next_segment(VFatOpenFile *fp, struct elf_parsed_data *t)
   kprintf("DEBUG allocated %d pages, first one is at 0x%x phys\r\n", allocd_pages, seg->content_phys_pages[0]);
 
   //Step two - (temporarily) map into kernel space as R/W so we can load them
-  cli();
   seg->content_virt_page = vm_map_next_unallocated_pages(NULL, MP_READWRITE, seg->content_phys_pages, seg->page_count);
-  sti();
   if(seg->content_virt_page==NULL) {
     kprintf("ERROR Could not map allocated pages into kernel-space\r\n");
-    cli();
     deallocate_physical_pages(allocd_pages, seg->content_phys_pages);
-    sti();
     free(seg->content_phys_pages);
     seg->content_phys_pages = NULL;
     t->callback(E_NOMEM,t, t->extradata);

--- a/andy_elf/utils/Makefile
+++ b/andy_elf/utils/Makefile
@@ -11,5 +11,8 @@ ucs_conv.o: ucs_conv.c ucs_conv.h
 string.o: string.asm
 	nasm -f elf32 string.asm
 
-libutils.a: ucs_conv.o string.o
-	ar rcs libutils.a ucs_conv.o string.o
+spinlock.o: spinlock.c ../include/spinlock.h
+	gcc -c ${CFLAGS} spinlock.c
+
+libutils.a: ucs_conv.o string.o spinlock.o
+	ar rcs libutils.a ucs_conv.o string.o spinlock.o

--- a/andy_elf/utils/spinlock.c
+++ b/andy_elf/utils/spinlock.c
@@ -1,0 +1,25 @@
+#include <types.h>
+#include <spinlock.h>
+
+/** 
+ * Atomically acquire the given lock if it's free, or loop until it is available
+*/
+void acquire_spinlock(spinlock_t *lock) {
+    asm(
+        ".acquire%=:\n\t"
+        "lock bts $0, (%0)\n\t"        //bts is "bit switch". This will set bit 0 to 1 and return the previous value in the "carry" flag
+        "jnc .wait_done%=\n\t"          //if the bit was 1 already, we are still locked, so wait
+        ".spin_wait%=:\n\t"
+        "pause\n\t"
+        "testw $1, (%0)\n\t"      //is it clear yet?
+        "jnz .spin_wait%=\n\t"
+        "jmp .acquire%=\n\t"
+        ".wait_done%=:"  : : "a"(lock) : "memory"   //once it's cleared, try to acquire again
+    );
+}
+
+void release_spinlock(spinlock_t *lock) {
+    asm(
+        "lock btc $0, (%0)\n\t" : : "r"(lock) : "memory"
+    );
+}


### PR DESCRIPTION
- First implementation of a spinlock to protect memory allocation routines
- Implementation of a low-level copy by dword routine that should give higher performance when copying whole pages
- Remove the old recursive page-allocation code that was causing a lot of problems. Instead, use sparse-mapping of the whole memory directory with a page-fault handler that can allocate memory just-in-time (both for kernel and process-under-load)
- Improve setup of process RAM areas
- Some work towards making processes load properly
