### PR TITLE
Fix - process re-entry

### DIFF
--- a/andy_elf/acpi/shortcut.c
+++ b/andy_elf/acpi/shortcut.c
@@ -2,7 +2,6 @@
 #include <acpi/rsdt.h>
 #include <acpi/fadt.h>
 #include <memops.h>
-#include <memory.h>
 
 struct AcpiTableShortcut *acpi_shortcut_list_end(struct AcpiTableShortcut *list) 
 {

--- a/andy_elf/drivers/kb/keyboard.c
+++ b/andy_elf/drivers/kb/keyboard.c
@@ -16,38 +16,23 @@ void init_keyboard() {
  */
 uint8_t kb_read_to_file(struct ProcessTableEntry *process, struct FilePointer *fp) {
     char ch = 0;
-    kputs("DEBUG kb_read_to_file\r\n");
-    kprintf("DEBUG fp read buffer 0x%x\r\n", fp->read_buffer);
+    // kputs("DEBUG kb_read_to_file\r\n");
+    // kprintf("DEBUG fp read buffer 0x%x\r\n", fp->read_buffer);
 
-    // uint8_t ch = ps2_get_buffer();
-    // ch = ps2_get_buffer();
-
-    // kprintf("\r\nDEBUG kb_read_to_file next char is 0x%x (%c)\r\n", (uint32_t)ch, ch);
-    // if(ch==0) {
-    //     process->status = PROCESS_IOWAIT; //this tells the scheduler not to schedule the process until IO is ready
-    //     fp->status = FP_STATUS_WAIT;
-    //     return 0;   //returning 0 from this function tells the landing pad to return to kernel idle loop instead of the process
-    // } else {
-    //     if(process->status==PROCESS_IOWAIT) process->status = PROCESS_READY;
-    //     fp->status = FP_STATUS_READY;
-    //     ring_buffer_push(fp->read_buffer, ch);
-    //     return ch;
-    // }
     ring_buffer_ref(fp->read_buffer);
     if(ring_buffer_empty(fp->read_buffer)) {
         //Nothing in the buffer, go to wait state
-        kputs("DEBUG kb buffer empty, going to wait\r\n");
+        //kputs("DEBUG kb buffer empty, going to wait\r\n");
         process->status = PROCESS_IOWAIT;
         fp->status = FP_STATUS_WAIT;
         kb_push_pending_operation(&kb_pending_ops, process, fp);
     } else {
         //We have something
-        kputs("DEBUG kb buffer has data, going to return\r\n");
+        //kputs("DEBUG kb buffer has data, going to return\r\n");
         ch = ring_buffer_pop(fp->read_buffer);
         if(process->status==PROCESS_IOWAIT) process->status = PROCESS_READY;
     }
     ring_buffer_unref(fp->read_buffer);
-    kprintf("DEBUG returning 0x%x\r\n", (uint32_t)ch);
     return ch;
 }
 
@@ -57,7 +42,6 @@ uint8_t kb_read_to_file(struct ProcessTableEntry *process, struct FilePointer *f
 void kb_notify_activity() {
     PendingOperationList *next_op = kb_pop_pending_operation(&kb_pending_ops);
     if(next_op && next_op->fp && next_op->fp->read_buffer) {
-        kprintf("kb_notify_activity");
         char ch = ps2_get_buffer();
         ring_buffer_ref(next_op->fp->read_buffer);
         ring_buffer_push(next_op->fp->read_buffer, ch);

--- a/andy_elf/drivers/kb/pending_operation_list.c
+++ b/andy_elf/drivers/kb/pending_operation_list.c
@@ -8,7 +8,6 @@
 static spinlock_t kb_pending_operation_lock;
 
 void init_kb_pending_ops() {
-    kprintf("DEBUG kb_pending_operation_lock at 0x%x\r\n", &kb_pending_operation_lock);
     kb_pending_operation_lock = 0;
     mb();
 }
@@ -114,16 +113,12 @@ PendingOperationList *kb_pop_pending_operation(PendingOperationList **start)
 PendingOperationList *kb_push_pending_operation(PendingOperationList **start, struct ProcessTableEntry *p, struct FilePointer *fp) 
 {
     PendingOperationList *last = *start;
-    kprintf("DEBUG POL start at 0x%x\r\n", start);
 
-    kputs("DEBUG kb_push_pending_operation malloc\r\n");
     PendingOperationList *new_entry = (PendingOperationList *)malloc(sizeof(PendingOperationList));
     if(!new_entry) {
         k_panic("Not enough memory to allocate a pending operation!\r\n");
     }
     memset((void *)new_entry, 0, sizeof(PendingOperationList));
-
-    kprintf("DEBUG kb_push_pending_operation entry is at 0x%x\r\n", new_entry);
 
     new_entry->process = p;
     new_entry->fp = fp;
@@ -131,7 +126,6 @@ PendingOperationList *kb_push_pending_operation(PendingOperationList **start, st
     acquire_spinlock(&kb_pending_operation_lock);
     //find the end of the list
     while(last && last->next) {
-        kprintf("DEBUG walk POL at 0x%x\r\n", last);
         last=last->next;
     }
 

--- a/andy_elf/drivers/ps2_controller/controller.c
+++ b/andy_elf/drivers/ps2_controller/controller.c
@@ -224,7 +224,7 @@ void ps2_put_buffer(uint8_t scancode)
 
     uint8_t ascii = lookup_scancode(scancode, &driver_state->kbd);
 
-    kprintf("DEBUG ps2_put_buffer 0x%x -> 0x%x '%c'\r\n", (size_t)scancode, (size_t)ascii, ascii);
+    //kprintf("DEBUG ps2_put_buffer 0x%x -> 0x%x '%c'\r\n", (size_t)scancode, (size_t)ascii, ascii);
 
     if(ascii==0) return;
     

--- a/andy_elf/drivers/ps2_controller/keymap.c
+++ b/andy_elf/drivers/ps2_controller/keymap.c
@@ -43,7 +43,7 @@ char lookup_scancode(char scancode, struct PS2KeyboardState* kbd_state)
     size_t keymap_pos = ( (scancode & 0xFF) * 2); //code 1 is at position 3+4 (0-based byte 2 + 3), there is no code 0
     if(kbd_state->shift_state || kbd_state->caps_lock) keymap_pos+=1;  //shifted equivalent is at +1
     if(keymap_pos>keymap_len) {
-        kprintf("ERROR scancode 0x%x out of range, limit was 0x%x\r\n", (uint32_t)(scancode & 0xFF), (uint32_t)keymap_len);
+        //kprintf("ERROR scancode 0x%x out of range, limit was 0x%x\r\n", (uint32_t)(scancode & 0xFF), (uint32_t)keymap_len);
         return 0;
     }
     return active_keymap_ptr[keymap_pos];

--- a/andy_elf/include/process.h
+++ b/andy_elf/include/process.h
@@ -58,6 +58,7 @@ struct SavedRegisterStates32 {
   uint32_t dr6;       //offset 0x40
   uint32_t dr7;       //offset 0x44
   uint32_t esp;       //offset 0x48
+  uint32_t eip;       //offset 0x4C
 } __attribute__((packed));
 
 #define PROCESS_TABLE_MAGIC_NUMBER  0x54504552

--- a/andy_elf/mmgr/heap.c
+++ b/andy_elf/mmgr/heap.c
@@ -388,15 +388,15 @@ void* _zone_alloc(struct HeapZoneStart *zone, size_t bytes)
     #endif
     
     // Extra validation for large allocations
-    if(bytes > 0x100000) { // 1MB+
-      kprintf("DEBUG Large allocation: ptr=0x%x, size=0x%x, zone=0x%x\r\n", ptr, bytes, zone);
-      kprintf("DEBUG Block header at 0x%x: magic=0x%x, block_length=0x%x, in_use=%d\r\n", 
-              p, p->magic, p->block_length, p->in_use);
-      if(new_ptr) {
-        kprintf("DEBUG Next block header at 0x%x: magic=0x%x, block_length=0x%x, in_use=%d\r\n",
-                new_ptr, new_ptr->magic, new_ptr->block_length, new_ptr->in_use);
-      }
-    }
+    // if(bytes > 0x100000) { // 1MB+
+    //   kprintf("DEBUG Large allocation: ptr=0x%x, size=0x%x, zone=0x%x\r\n", ptr, bytes, zone);
+    //   kprintf("DEBUG Block header at 0x%x: magic=0x%x, block_length=0x%x, in_use=%d\r\n", 
+    //           p, p->magic, p->block_length, p->in_use);
+    //   if(new_ptr) {
+    //     kprintf("DEBUG Next block header at 0x%x: magic=0x%x, block_length=0x%x, in_use=%d\r\n",
+    //             new_ptr, new_ptr->magic, new_ptr->block_length, new_ptr->in_use);
+    //   }
+    // }
 
     return ptr;
   }

--- a/andy_elf/mmgr/mmgr.c
+++ b/andy_elf/mmgr/mmgr.c
@@ -973,6 +973,7 @@ uint32_t *initialise_app_pagingdir(void **phys_ptr_list, size_t phys_ptr_count)
   uint32_t *stack_paging_table_virt = (uint32_t *) (temp_ptr + (2*PAGE_SIZE));  
   uint32_t *stack_initial_page_virt = (uint32_t *) (temp_ptr + (3*PAGE_SIZE)); 
 
+  memset_dw(root_dir_virt, 0, PAGE_SIZE_DWORDS);
   //POTENTIAL BUG - by copying the kernel paging directory here, the page table entries get freed when the process exits
   //and then the kernel crashes when it tries to access them.  This is now prevented by ensuring that the kernel page tables are
   //marked as MP_GLOBAL so the freeing process will skip them.

--- a/andy_elf/mmgr/process.c
+++ b/andy_elf/mmgr/process.c
@@ -336,12 +336,13 @@ pid_t internal_create_process(struct elf_parsed_data *elf)
 
   #ifdef PROCESS_VERBOSE
   kprintf("DEBUG new_process unmapping process stack at 0x%x from kernel\r\n", new_entry->stack_kmem_ptr);
+  dump_process_struct(new_entry);
   #endif
   k_unmap_page_ptr(NULL, new_entry->stack_kmem_ptr);
   new_entry->stack_kmem_ptr = NULL;
 
   new_entry->status = PROCESS_READY;
-  dump_process_struct(new_entry);
+
   
   sti();
   #ifdef PROCESS_VERBOSE

--- a/andy_elf/mmgr/process.c
+++ b/andy_elf/mmgr/process.c
@@ -86,6 +86,43 @@ struct ProcessTableEntry* get_current_process()
   return get_process(get_current_processid());
 }
 
+void dump_process_struct(struct ProcessTableEntry *p)
+{
+  if(!p) {
+    kputs("dump_process_struct: NULL process pointer\r\n");
+    return;
+  }
+  kprintf("Process Table Entry at 0x%x\r\n", p);
+  kprintf(" Magic: 0x%x\r\n", p->magic);
+  kprintf(" PID: %d\r\n", p->pid);
+  kprintf(" Status: %d\r\n", (uint16_t)p->status);
+  kprintf(" Stack Page Count: %d\r\n", (uint16_t)p->stack_page_count);
+  kprintf(" Root Paging Directory (phys): 0x%x\r\n", p->root_paging_directory_phys);
+  kprintf(" Root Paging Directory (kmem): 0x%x\r\n", p->root_paging_directory_kmem);
+  kprintf(" Heap Start: 0x%x\r\n", p->heap_start);
+  kprintf(" Heap Allocated: %l bytes\r\n", p->heap_allocated);
+  kprintf(" Heap Used: %l bytes\r\n", p->heap_used);
+  kprintf(" Stack Phys Ptr: 0x%x\r\n", p->stack_phys_ptr);
+  kprintf(" Stack Kmem Ptr: 0x%x\r\n", p->stack_kmem_ptr);
+  kprintf(" Saved Registers:\r\n");
+  kprintf("  EAX: 0x%x\r\n", p->saved_regs.eax);
+  kprintf("  EBX: 0x%x\r\n", p->saved_regs.ebx);
+  kprintf("  ECX: 0x%x\r\n",  p->saved_regs.ecx);
+  kprintf("  EDX: 0x%x\r\n", p->saved_regs.edx);
+  kprintf("  EBP: 0x%x\r\n", p->saved_regs.ebp);
+  kprintf("  ESI: 0x%x\r\n", p->saved_regs.esi);
+  kprintf("  EDI: 0x%x\r\n", p->saved_regs.edi);
+  kprintf("  EFLAGS: 0x%x\r\n", p->saved_regs.eflags);
+  kprintf("  CS: 0x%x\r\n", p->saved_regs.cs);
+  kprintf("  DS: 0x%x\r\n", p->saved_regs.ds);
+  kprintf("  ES: 0x%x\r\n", p->saved_regs.es);
+  kprintf("  FS: 0x%x\r\n", p->saved_regs.fs);
+  kprintf("  GS: 0x%x\r\n", p->saved_regs.gs);
+  kprintf("  ESP: 0x%x\r\n", p->saved_regs.esp);
+  kprintf("  EIP: 0x%x\r\n", p->saved_regs.eip);
+  
+}
+
 //INTERNAL USE ONLY! Called when entering kernel context.
 uint16_t set_current_process_id(uint16_t pid)
 {

--- a/andy_elf/mmgr/process.h
+++ b/andy_elf/mmgr/process.h
@@ -10,4 +10,9 @@ void initialise_process_table(uint32_t* kernel_paging_directory);
 pid_t internal_create_process(struct elf_parsed_data *elf);
 void remove_process(struct ProcessTableEntry* e);
 
+//INTERNAL USE ONLY! Called by the scheduler when switching processes.
+uint16_t set_current_process_id(uint16_t pid);
+//Get the process table entry for a given pid
+struct ProcessTableEntry* get_process(uint16_t pid);
+
 #endif

--- a/andy_elf/native_api/process_ops.c
+++ b/andy_elf/native_api/process_ops.c
@@ -7,11 +7,11 @@ void api_terminate_current_process()
     pid_t current_pid = get_active_pid();
     struct ProcessTableEntry *entry = get_process(current_pid);
     if(entry==NULL) {
-        kprintf("ERROR No process entry found for %d\r\n", current_pid);
+        kprintf("\r\nERROR No process entry found for %d\r\n", current_pid);
         return;
     }
 
-    kprintf("DEBUG api_terminate PID %d is at 0x%x\r\n", current_pid, entry);
+    kprintf("\r\nDEBUG api_terminate PID %d is at 0x%x\r\n", current_pid, entry);
     entry->status = PROCESS_TERMINATING;
     schedule_cleanup_task(current_pid);
 }

--- a/andy_elf/native_api/stream_ops.c
+++ b/andy_elf/native_api/stream_ops.c
@@ -28,7 +28,7 @@ size_t api_read(uint32_t fd, char *buf, size_t len)
   char ch;
 
   pid_t current_pid = get_active_pid();
-  kprintf("\r\nDEBUG api_read on file 0x%x current PID is 0x%d\r\n", fd, current_pid);
+  //kprintf("\r\nDEBUG api_read on file 0x%x current PID is 0x%d\r\n", fd, current_pid);
   
   if(fd > FILE_MAX) return API_ERR_NOTSUPP;
 
@@ -67,7 +67,7 @@ size_t api_write(uint32_t fd, char *buf, size_t len)
 {
   if(fd > FILE_MAX) return API_ERR_NOTSUPP;
   pid_t current_pid = get_active_pid();
-  kprintf("DEBUG api_write current PID is 0x%d\r\n", current_pid);
+  //kprintf("DEBUG api_write current PID is 0x%d\r\n", current_pid);
   if(current_pid==0) {
     return API_ERR_NOTSUPP;
   }

--- a/andy_elf/process/elfloader.c
+++ b/andy_elf/process/elfloader.c
@@ -255,7 +255,7 @@ void _elf_loaded_file_header(VFatOpenFile *fp, uint8_t status, size_t bytes_read
     return;
   }
   //check the OS ABI (we imply Linux support for compatibility with existing tools)
-  if(header->ident_os_abi != ELF_ABI_SILLY && header->ident_os_abi != ELF_ABI_LINUX) {
+  if(header->ident_os_abi != ELF_ABI_SILLY && header->ident_os_abi != ELF_ABI_LINUX && header->ident_os_abi!=0) {
     kprintf("ERROR: Unsupported ELF OS ABI %d\r\n", header->ident_os_abi);
     t->callback(E_UNSUPPORTED_ELF, t->parsed_data, t->extradata);
     free(t);

--- a/andy_elf/scheduler/lowlevel.asm
+++ b/andy_elf/scheduler/lowlevel.asm
@@ -51,7 +51,6 @@ exit_to_process:
   mov ebx, [edi+0x04] ;EBX
 
   ;Get hold of the application paging directory physical address and activate it.
-  ;This will remove access to the kernel stack.
   sub edi, 0x28       ;Location of SavedRegisterStates32 within the ProcessTableEntry
   mov eax, [edi+0x0C] ;Location of Page Directory Physical Address within the ProcessTableEntry
   mov cr3, eax
@@ -75,83 +74,6 @@ exit_to_process:
   mov eax, [edi+0x00] ;EAX
   mov edi, [edi+0x18] ;EDI
   iret ;go back to process
-
-temp_old:
-  xor eax, eax
-
-  mov ax, 0x33      ;FIXME: direct reference to user data seg OR DPL 3
-  mov ds, ax
-  mov es, ax
-  mov fs, ax
-  mov gs, ax
-
-  mov edi, [esp+4]  ;grab the first argument from the stack
-  ;Set the current stack pointer in the TSS TO THE APPLICATION STACK. When we return to the kernel we
-  ;will effectively have exited from this function. in the stack context of the application.
-  ;Get the application stack pointer and store it in a register
-  mov esi, edi
-  add esi, 0x28       ;Location of SavedRegisterStates32 within the ProtessTableEntry
-  mov ebx, [esi+0x48] ;location of ESP in SavedRegisterStates32
-
-
-  ;Set up a stack frame so we can return to the kernel easily after an int call. CPU expects to pop EIP, CS, EFLAGS in that order
-  pushf
-  mov ax, cs
-  push eax
-  mov eax, idle_loop ;idle_loop is a label defined in kickoff.s and it's where we want to get back to
-  push eax
-
-  mov eax, 0x7FFF8                      ;We are exiting the kernel, so re-set the stack to the bottom for when we re-enter
-  mov [saved_stack_pointer], eax    ;save the stack pointer to our data area so that we can get it back easily
-
-  mov esi, FullTSS
-  mov DWORD [esi+0x04], ebx
-
-  ;Get hold of the application paging directory physical address and activate it.
-  ;This will remove access to the kernel stack.
-  mov eax, [edi+0x0C]
-  mov cr3, eax
-  ;set the stack pointer
-  mov esp, ebx
-
-  ;restore the register states from the process struct
-  ;first, deal with EFLAGS
-  mov eax, [esi+0x1C]
-  push eax
-  popf
-  ;now get the ESI value we want and put that on the stack for when we have finished
-  mov eax, [esi+0x14]
-  push eax
-
-  ;ignore segment selector registers as there is no other valid value for them to have
-
-  ;debug registers
-  mov eax, [esi+0x30]
-  mov dr0, eax
-  mov eax, [esi+0x34]
-  mov dr1, eax
-  mov eax, [esi+0x38]
-  mov dr2, eax
-  mov eax, [esi+0x3C]
-  mov dr3, eax
-  mov eax, [esi+0x40]
-  mov dr6, eax
-  mov eax, [esi+0x44]
-  mov dr7, eax
-
-  ;general-use registers
-  mov eax, [esi+0x00]
-  mov ebx, [esi+0x04]
-  mov ecx, [esi+0x08]
-  mov edx, [esi+0x0C]
-  mov ebp, [esi+0x10]
-  ;can't set esi yet, come back to it!
-  mov edi, [esi+0x18]
-
-
-  ;finally, restore esi from the stack
-  pop esi
-  iret
 
 ;Purpose: Saves the current process state into its ProcessTableEntry and switches to kernel context.
 ; Note: assumes that the preceding stack frame is that of an interrupt handler, so the stack pointer

--- a/andy_elf/scheduler/lowlevel.asm
+++ b/andy_elf/scheduler/lowlevel.asm
@@ -20,9 +20,6 @@ exit_to_process:
   mov [saved_stack_pointer], eax    ;save the stack pointer to our data area so that we can get it back easily
   
   mov edi, [esp+4]  ;grab the first argument from the stack (pointer to ProcessTableEntry)
-  push edi
-  call dump_process_struct
-  add esp, 4
 
   ;Set up registers for the process based on saved state in the process struct
   add edi, 0x28       ;Location of SavedRegisterStates32 within the ProcessTableEntry
@@ -169,9 +166,6 @@ switch_out_process:
   test eax, eax
   jz .no_process            ;if no current process, just return
   mov edi, eax
-  push edi
-  call dump_process_struct
-  add esp, 4
 
   add edi, 0x28            ;offset of SavedRegisterStates32 in the struct
   mov eax, [ebp-0x20]  ;EAX
@@ -220,11 +214,6 @@ switch_out_process:
 
 .no_process:
 add esp, 0x20  ;clean up the stack from pushad
-extern dump_process_struct
-sub edi, 0x28            ;offset of SavedRegisterStates32 in the struct
-push edi
-call dump_process_struct
-add esp, 4
 
 pop ebp
 pop edi         ;pop the return address from the stack

--- a/andy_elf/scheduler/scheduler.c
+++ b/andy_elf/scheduler/scheduler.c
@@ -173,8 +173,6 @@ void enter_next_process()
   //Right, we have something.  We must switch process.
   last_run_pid = temp;
   active_process = temp;
-  // kprintf("DEBUG process saved esp 0x%x\r\n", process->saved_regs.esp);
-  // kprintf("DEBUG Exiting into process 0x%x\r\n", process);
 
   //Update the system state to reflect the process switch
   set_current_process_id(process->pid);

--- a/andy_elf/scheduler/scheduler.c
+++ b/andy_elf/scheduler/scheduler.c
@@ -175,7 +175,11 @@ void enter_next_process()
   active_process = temp;
   kprintf("DEBUG process saved esp 0x%x\r\n", process->saved_regs.esp);
   kprintf("DEBUG Exiting into process 0x%x\r\n", process);
+
+  //Update the system state to reflect the process switch
   set_current_process_id(process->pid);
+  //Update the process status so it does not accidentally get re-scheduled while running
+  process->status = PROCESS_BUSY;
   exit_to_process(process);
 }
 

--- a/andy_elf/scheduler/scheduler.c
+++ b/andy_elf/scheduler/scheduler.c
@@ -175,7 +175,7 @@ void enter_next_process()
   active_process = temp;
   kprintf("DEBUG process saved esp 0x%x\r\n", process->saved_regs.esp);
   kprintf("DEBUG Exiting into process 0x%x\r\n", process);
-
+  set_current_process_id(process->pid);
   exit_to_process(process);
 }
 

--- a/andy_elf/scheduler/scheduler.c
+++ b/andy_elf/scheduler/scheduler.c
@@ -173,8 +173,8 @@ void enter_next_process()
   //Right, we have something.  We must switch process.
   last_run_pid = temp;
   active_process = temp;
-  kprintf("DEBUG process saved esp 0x%x\r\n", process->saved_regs.esp);
-  kprintf("DEBUG Exiting into process 0x%x\r\n", process);
+  // kprintf("DEBUG process saved esp 0x%x\r\n", process->saved_regs.esp);
+  // kprintf("DEBUG Exiting into process 0x%x\r\n", process);
 
   //Update the system state to reflect the process switch
   set_current_process_id(process->pid);

--- a/shell.app/Makefile
+++ b/shell.app/Makefile
@@ -7,5 +7,4 @@ start.o: start.asm
 	nasm -f elf32 start.asm
 
 shell.app: start.o
-	ld -b elf32-i386 start.o \
-		-static -nostartfiles -nodefaultlibs -nostdlib -nolibc -m elf_i386 --oformat elf32-i386 -o shell.app
+	ld -m elf_i386 --oformat elf32-i386 -nostdlib start.o -o shell.app


### PR DESCRIPTION
Fixes the longstanding "process restarts when resuming from IO wait" bug.  This is done by rewriting the enter kernel/exit to process routines:

- `enter_kernel_context` is replaced by `switch_out_process`.  Since the kernel is now mapped into process-space on protected memory pages, we can simply save the CPU state directly into the process table.
- `switch_out_process` is only called on exit from native api if we are going back to kernel idle
- **FIXME** - ~~check if we switch-out properly when pre-empting~~
- `exit_to_process` is rewritten to rebuild the exiting stack frame from the saved process state rather than assuming it's there
- **FIXME** - ~~we currently always assume that we came from ring3, should accomodate the different stack frame format if we came from ring 0~~
- Quieten logs
- Fix longstanding compilation issue with a misused header